### PR TITLE
upgrade rpi.gpio to support raspberry pi 4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 adafruit-circuitpython-dht==3.6.0
 paho-mqtt==1.5.1
-rpi.gpio==0.7.0
+# pre-release to support raspberry pi 4
+# https://sourceforge.net/p/raspberry-gpio-python/tickets/190/
+rpi.gpio==0.7.1a4


### PR DESCRIPTION
see https://github.com/hvalev/dht22mqtt-homeassistant-docker/issues/9