### PR TITLE
add support for mqtt authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The container offers the following configurable environment variables:</br>
 | ```topic``` |  | MQTT topic to submit to. | ```zigbee2mqtt```  |
 | ```device_id``` |  | Unique identifier for the device. \*If you have multiple, you could use something like ```bedroom_dht22```. | ```dht22``` |
 | ```broker``` |  | MQTT broker ip address. | ```192.168.1.10``` |
+| ```username``` |  | MQTT username. | `None` |
+| ```password``` |  | MQTT password. | `None` |
 | ```pin``` |  | GPIO data pin your sensor is hooked up to. | ```4``` |
 | ```poll``` |  | Sampling rate in seconds. Recommended is the range between 2 to 30 seconds. Further information: [*DHT11/DHT22/AM2302 spec sheet.*](https://lastminuteengineers.com/dht11-dht22-arduino-tutorial/) | ```2``` |
 | ```device_type``` | ```dht11``` or ```dht22``` | Sensor type. ```dht22``` also also works for AM2302 | ```dht22``` |

--- a/dht22mqtt.py
+++ b/dht22mqtt.py
@@ -18,6 +18,8 @@ dht22mqtt_start_ts = datetime.now()
 mqtt_topic = os.getenv('topic', 'zigbee2mqtt/')
 mqtt_device_id = os.getenv('device_id', 'dht22')
 mqtt_brokeraddr = os.getenv('broker', '192.168.1.10')
+mqtt_username = os.getenv('username', None)
+mqtt_password = os.getenv('password', None)
 if not mqtt_topic.endswith('/'):
     mqtt_topic = mqtt_topic + "/"
 mqtt_topic = mqtt_topic + mqtt_device_id + '/'
@@ -198,6 +200,9 @@ log2stdout(datetime.now().timestamp(), 'Setup dht22 sensor success...')
 if('essential' in dht22mqtt_mqtt_chatter):
     client = mqtt.Client('DHT22', clean_session=True, userdata=None)
 
+    if mqtt_username:
+        client.username_pw_set(username=mqtt_username, password=mqtt_password)
+
     # set last will for an ungraceful exit
     client.will_set(mqtt_topic + "state", "OFFLINE", qos=1, retain=True)
 
@@ -212,6 +217,7 @@ if('essential' in dht22mqtt_mqtt_chatter):
     if('full' in dht22mqtt_mqtt_chatter):
         client.publish(mqtt_topic + "env/pin", dht22mqtt_pin, qos=1, retain=True)
         client.publish(mqtt_topic + "env/brokeraddr", mqtt_brokeraddr, qos=1, retain=True)
+        client.publish(mqtt_topic + "env/username", mqtt_username, qos=1, retain=True)
         client.publish(mqtt_topic + "env/refresh", dht22mqtt_refresh, qos=1, retain=True)
         client.publish(mqtt_topic + "env/logging", dht22mqtt_logging_mode, qos=1, retain=True)
         client.publish(mqtt_topic + "env/mqtt_chatter", dht22mqtt_mqtt_chatter, qos=1, retain=True)


### PR DESCRIPTION
My MQTT broker requires authentication.

I wrote ` if mqtt_username:` instead of ` if mqtt_username and mqtt_password:` or similar because the password is optional:
https://github.com/eclipse/paho.mqtt.python/blob/v1.5.1/src/paho/mqtt/client.py#L1318